### PR TITLE
Fix benchmarking.

### DIFF
--- a/workflow/rules/01_functions.smk
+++ b/workflow/rules/01_functions.smk
@@ -3,7 +3,9 @@
 
 def get_reads_path(name, stage):
     reads = manifest.reads.get(name)
-    return reads.paths(stage)
+    reads_paths = reads.paths(stage)
+    reads_strings = {k: str_path(v) for k, v in reads_paths.items()}
+    return reads_strings
 
 
 def get_raw_reads(wildcards):
@@ -24,3 +26,12 @@ def get_git_info():
     hash = repo.head.object.hexsha
     parsed = giturlparse.parse(repo.remotes[0].url)
     return {"git_repo": f"{parsed.owner}/{parsed.repo}", "git_commit_hash": hash}
+
+
+def str_path(*args, **kwargs):
+    """
+    Path() objects aren't serialised properly if extended_benchmark is used.
+    Use this function instead of Path() whenever the rule has benchmarking
+    enabled.
+    """
+    return str(Path(*args, **kwargs))

--- a/workflow/rules/10_assembly_data_downloader.smk
+++ b/workflow/rules/10_assembly_data_downloader.smk
@@ -28,14 +28,14 @@ rule collect_lane_files:
 
 rule download_file:
     output:
-        read_file=temp(Path("{raw_file}")),
-        check_file=temp(Path("{raw_file}.check.txt")),
+        read_file=temp(str_path("{raw_file}")),
+        check_file=temp(str_path("{raw_file}.check.txt")),
     log:
-        Path(manifest.get_stage_logs("raw"), "download_file", "{raw_file}.log"),
+        str_path(manifest.get_stage_logs("raw"), "download_file", "{raw_file}.log"),
     benchmark:
-        Path(
+        str_path(
             manifest.get_stage_logs("raw"), "download_file", "{raw_file}.stats.jsonl"
-        ).as_posix()
+        )
     wildcard_constraints:
         raw_file="|".join([str(x) for x in manifest.reads.all_raw_paths]),
     retries: 2

--- a/workflow/rules/11_pipeline_result_uploader.smk
+++ b/workflow/rules/11_pipeline_result_uploader.smk
@@ -13,15 +13,13 @@ rule pipeline_result_uploader:
     input:
         manifest=config["manifest"],
     output:
-        receipts=Path(
+        receipts=str_path(
             manifest.get_dir("results"), "upload_receipts", "{pipeline}.jsonl"
         ),
     log:
-        Path(log_dir_base, "{pipeline}", "pipeline_result_uploader.log"),
+        str_path(log_dir_base, "{pipeline}", "pipeline_result_uploader.log"),
     benchmark:
-        Path(
-            log_dir_base, "{pipeline}", "pipeline_result_uploader.stats.jsonl"
-        ).as_posix()
+        str_path(log_dir_base, "{pipeline}", "pipeline_result_uploader.stats.jsonl")
     container:
         config["containers"]["atol_genome_launcher"]
     threads: 8

--- a/workflow/rules/12_status_updates.smk
+++ b/workflow/rules/12_status_updates.smk
@@ -16,9 +16,10 @@ def get_github_token(wildcards):
 
 def assembly_status_input(wildcards):
     if wildcards.pipeline == "qc":
-        return manifest.reads.flat_paths("qc")
+        flat_paths = [str_path(x) for x in manifest.reads.flat_paths("qc")]
+        return flat_paths
     return (
-        Path(
+        str_path(
             manifest.get_dir("results"),
             "upload_receipts",
             f"{wildcards.pipeline}.jsonl",
@@ -38,13 +39,13 @@ rule update_assembly_status:
     input:
         receipts=assembly_status_input,
     output:
-        response=Path(
+        response=str_path(
             manifest.get_dir("results"), "update_assembly_status", "{pipeline}.json"
         ),
     log:
-        Path("logs", "update_assembly_status", "{pipeline}.log"),
+        str_path("logs", "update_assembly_status", "{pipeline}.log"),
     benchmark:
-        Path("logs", "update_assembly_status", "{pipeline}.stats.jsonl").as_posix()
+        str_path("logs", "update_assembly_status", "{pipeline}.stats.jsonl")
     wildcard_constraints:
         pipeline="|".join(list(assembly_status.keys())),
     container:

--- a/workflow/rules/20_pacbio_qc.smk
+++ b/workflow/rules/20_pacbio_qc.smk
@@ -11,12 +11,12 @@ if len(pacbio_reads) > 0:
         input:
             ancient(unpack(get_raw_reads)),
         output:
-            fastq=Path(pacbio_fastq_parent, "{bpa_package_id}.fastq.gz"),
-            stats=Path(pacbio_stats_parent, "{bpa_package_id}.json"),
+            fastq=str_path(pacbio_fastq_parent, "{bpa_package_id}.fastq.gz"),
+            stats=str_path(pacbio_stats_parent, "{bpa_package_id}.json"),
         log:
-            Path(pacbio_log_parent, "{bpa_package_id}.log"),
+            str_path(pacbio_log_parent, "{bpa_package_id}.log"),
         benchmark:
-            Path(pacbio_log_parent, "{bpa_package_id}.stats.jsonl").as_posix()
+            str_path(pacbio_log_parent, "{bpa_package_id}.stats.jsonl")
         container:
             config["containers"]["atol_qc_raw_pacbio"]
         threads: 8
@@ -25,7 +25,7 @@ if len(pacbio_reads) > 0:
             runtime="4h",
         params:
             mem_gb=lambda wildcards, resources: resources.mem_mb // 1000,
-            qc_logs_dir=lambda wildcards: Path(qc_logs_dir, wildcards.bpa_package_id),
+            qc_logs_dir=lambda wildcards: str_path(qc_logs_dir, wildcards.bpa_package_id),
         shell:
             "atol-qc-raw-pacbio "
             "--bam {input.single_end} "

--- a/workflow/rules/21_ont_qc.smk
+++ b/workflow/rules/21_ont_qc.smk
@@ -12,12 +12,12 @@ if len(ont_reads) > 0:
         input:
             ancient(unpack(get_raw_reads)),
         output:
-            fastq=Path(ont_fastq_parent, "{bpa_package_id}.fastq.gz"),
-            stats=Path(ont_stats_parent, "{bpa_package_id}.json"),
+            fastq=str_path(ont_fastq_parent, "{bpa_package_id}.fastq.gz"),
+            stats=str_path(ont_stats_parent, "{bpa_package_id}.json"),
         log:
-            Path(ont_log_parent, "{bpa_package_id}.log"),
+            str_path(ont_log_parent, "{bpa_package_id}.log"),
         benchmark:
-            Path(ont_log_parent, "{bpa_package_id}.stats.jsonl").as_posix()
+            str_path(ont_log_parent, "{bpa_package_id}.stats.jsonl")
         container:
             config["containers"]["atol_qc_raw_ont"]
         threads: lambda wildcards, attempt: int(64 * attempt)
@@ -25,7 +25,9 @@ if len(ont_reads) > 0:
             mem=lambda wildcards, attempt: f"{int(255* attempt)}GB",
             runtime="24h",
         params:
-            qc_logs_dir=lambda wildcards: Path(qc_logs_dir, wildcards.bpa_package_id),
+            qc_logs_dir=lambda wildcards: str_path(
+                qc_logs_dir, wildcards.bpa_package_id
+            ),
             min_length=1000,
         shell:
             "atol-qc-raw-ont "

--- a/workflow/rules/25_hic_qc.smk
+++ b/workflow/rules/25_hic_qc.smk
@@ -11,12 +11,12 @@ if len(hic_reads) > 0:
         input:
             ancient(unpack(get_raw_reads)),
         output:
-            cram=Path(hic_cram_parent, "{bpa_package_id}.cram"),
-            stats=Path(hic_stats_parent, "{bpa_package_id}.json"),
+            cram=str_path(hic_cram_parent, "{bpa_package_id}.cram"),
+            stats=str_path(hic_stats_parent, "{bpa_package_id}.json"),
         log:
-            Path(hic_log_parent, "{bpa_package_id}.log"),
+            str_path(hic_log_parent, "{bpa_package_id}.log"),
         benchmark:
-            Path(hic_log_parent, "{bpa_package_id}.stats.jsonl").as_posix()
+            str_path(hic_log_parent, "{bpa_package_id}.stats.jsonl")
         container:
             config["containers"]["atol_qc_raw_shortread"]
         threads: 12
@@ -26,7 +26,9 @@ if len(hic_reads) > 0:
         params:
             dataset_id=manifest.dataset_id,
             hic_kit=config["hic_kit"],
-            qc_logs_dir=lambda wildcards: Path(qc_logs_dir, wildcards.bpa_package_id),
+            qc_logs_dir=lambda wildcards: str_path(
+                qc_logs_dir, wildcards.bpa_package_id
+            ),
         shell:
             "atol-qc-raw-shortread "
             "--cram {output.cram} "

--- a/workflow/rules/28_ena_raw_data_upload.smk
+++ b/workflow/rules/28_ena_raw_data_upload.smk
@@ -3,8 +3,8 @@
 
 def get_broker_input(wildcards):
     read_file = manifest.reads.get(wildcards.bpa_package_id)
-    reads = read_file.paths("qc")
-    reads["stats_file"] = read_file.stats_path("qc")
+    reads = {k: str_path(v) for k, v in read_file.paths("qc").items()}
+    reads["stats_file"] = str_path(read_file.stats_path("qc"))
     return reads
 
 
@@ -13,7 +13,7 @@ def generate_md5sum_file(wildcards, input):
         stats_data = json.load(f)
     input_reads_name = Path(input.reads).name
     md5sum = stats_data.get("checksums").get(input_reads_name).get("md5")
-    md5sum_file = Path(tempfile.mkdtemp(), f"{input_reads_name}.md5")
+    md5sum_file = str_path(tempfile.mkdtemp(), f"{input_reads_name}.md5")
     with open(md5sum_file, "wt") as f:
         f.write(f"{md5sum} {input_reads_name}\n")
     return md5sum_file
@@ -42,17 +42,15 @@ rule broker_raw_reads:
         unpack(get_broker_input),
     output:
         touch(
-            Path(
+            str_path(
                 manifest.get_dir("results"), "brokered_reads", "{bpa_package_id}.done"
             )
         ),
     log:
-        log=Path(log_dir_base, "broker_raw_reads", "{bpa_package_id}.log"),
-        stats=Path(log_dir_base, "broker_raw_reads", "{bpa_package_id}.json"),  # Bytes per second
+        log=str_path(log_dir_base, "broker_raw_reads", "{bpa_package_id}.log"),
+        stats=str_path(log_dir_base, "broker_raw_reads", "{bpa_package_id}.json"),  # Bytes per second
     benchmark:
-        Path(
-            log_dir_base, "broker_raw_reads", "{bpa_package_id}.stats.jsonl"
-        ).as_posix()
+        str_path(log_dir_base, "broker_raw_reads", "{bpa_package_id}.stats.jsonl")
     container:
         config["containers"]["curl"]
     resources:

--- a/workflow/rules/29_format_conversions.smk
+++ b/workflow/rules/29_format_conversions.smk
@@ -12,15 +12,13 @@ def get_haplotype_assemblies(wildcards):
 # TODO: generalise
 rule reformat_fq_to_fa:
     input:
-        ancient(Path("{folder}", "{file}.fastq.gz")),
+        ancient(str_path("{folder}", "{file}.fastq.gz")),
     output:
-        Path("{folder}", "{file}.fasta.gz"),
+        str_path("{folder}", "{file}.fasta.gz"),
     log:
-        Path(log_dir_base, "reformat", "{folder}", "{file}", "to_fasta.log"),
+        str_path(log_dir_base, "reformat", "{folder}", "{file}", "to_fasta.log"),
     benchmark:
-        Path(
-            log_dir_base, "reformat", "{folder}", "{file}", "to_fasta.stats.jsonl"
-        ).as_posix()
+        str_path(log_dir_base, "reformat", "{folder}", "{file}", "to_fasta.stats.jsonl")
     wildcard_constraints:
         file="|".join(
             [

--- a/workflow/rules/30_stage_busco_dataset.smk
+++ b/workflow/rules/30_stage_busco_dataset.smk
@@ -38,20 +38,22 @@ def read_manifest(manifest):
 
 rule expand_busco_lineage_files:
     input:
-        busco_dataset=Path("resources", "busco_lineage_files", "{busco_dataset}.tar.gz"),
+        busco_dataset=str_path(
+            "resources", "busco_lineage_files", "{busco_dataset}.tar.gz"
+        ),
     output:
         lineage_directory=directory(
-            Path("resources", "staging", "busco", "lineages", "{busco_dataset}")
+            str_path("resources", "staging", "busco", "lineages", "{busco_dataset}")
         ),
     log:
-        Path("logs", "staging", "expand_busco_lineage_files", "{busco_dataset}.log"),
+        str_path("logs", "staging", "expand_busco_lineage_files", "{busco_dataset}.log"),
     benchmark:
-        Path(
+        str_path(
             "logs",
             "staging",
             "expand_busco_lineage_files",
             "{busco_dataset}.stats.jsonl",
-        ).as_posix()
+        )
     container:
         config["containers"]["pigz"]
     resources:
@@ -64,18 +66,22 @@ rule expand_busco_lineage_files:
 
 rule download_busco_lineage_files:
     input:
-        busco_manifest=Path("resources", "busco_lineage_files", "file_versions.tsv"),
+        busco_manifest=str_path("resources", "busco_lineage_files", "file_versions.tsv"),
     output:
-        busco_dataset=Path("resources", "busco_lineage_files", "{busco_dataset}.tar.gz"),
+        busco_dataset=str_path(
+            "resources", "busco_lineage_files", "{busco_dataset}.tar.gz"
+        ),
     log:
-        Path("logs", "staging", "download_busco_lineage_files", "{busco_dataset}.log"),
+        str_path(
+            "logs", "staging", "download_busco_lineage_files", "{busco_dataset}.log"
+        ),
     benchmark:
-        Path(
+        str_path(
             "logs",
             "staging",
             "download_busco_lineage_files",
             "{busco_dataset}.stats.jsonl",
-        ).as_posix()
+        )
     retries: 3
     shadow:
         "minimal"
@@ -93,11 +99,11 @@ rule download_busco_lineage_files:
 
 rule download_busco_manifest:
     output:
-        busco_manifest=Path("resources", "busco_lineage_files", "file_versions.tsv"),
+        busco_manifest=str_path("resources", "busco_lineage_files", "file_versions.tsv"),
     log:
-        Path("logs", "staging", "download_busco_manifest.log"),
+        str_path("logs", "staging", "download_busco_manifest.log"),
     benchmark:
-        Path("logs", "staging", "download_busco_manifest.stats.jsonl").as_posix()
+        str_path("logs", "staging", "download_busco_manifest.stats.jsonl")
     container:
         config["containers"]["wget"]
     params:

--- a/workflow/rules/31_stage_s3_bucket.smk
+++ b/workflow/rules/31_stage_s3_bucket.smk
@@ -11,11 +11,11 @@ def get_bucket(wildcards):
 # container creation failed` error for ANY job that uses a container.
 rule stage_s3_bucket:
     output:
-        staging_dir=directory(Path("resources", "staging", "{bucket_name}")),
+        staging_dir=directory(str_path("resources", "staging", "{bucket_name}")),
     log:
-        Path("logs", "stage_s3_bucket", "{bucket_name}.log"),
+        str_path("logs", "stage_s3_bucket", "{bucket_name}.log"),
     benchmark:
-        Path("logs", "stage_s3_bucket", "{bucket_name}.stats.jsonl").as_posix()
+        str_path("logs", "stage_s3_bucket", "{bucket_name}.stats.jsonl")
     wildcard_constraints:
         bucket_name="|".join(config.get("s3_buckets").keys()),
     container:


### PR DESCRIPTION
> [!IMPORTANT]
>
> Tag a release and update the assembly-datasets workflow config.

Path() objects must be strings for rules with benchmarks.

This is a workaround for https://github.com/snakemake/snakemake/issues/3916.